### PR TITLE
Correctly check whether we need to set grepformat

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -266,7 +266,7 @@ function! s:set_settings(prog) abort
   let &grepprg = a:prog.grepprg
   let &makeprg = a:prog.grepprg
 
-  if has_key(a:prog, 'format')
+  if has_key(a:prog, 'grepformat')
     let s:settings.grepformat  = &grepformat
     let s:settings.errorformat = &errorformat
     let &grepformat  = a:prog.grepformat


### PR DESCRIPTION
When the tool's 'format' option was changed to 'grepformat', one place was not updated. Because of this, 'grepformat' was never set to the required value for a tool.