### PR TITLE
Improved quickfix handling with title

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -23,3 +23,8 @@ for [cmd, tool] in cmds
           \ 'Grepper -noprompt -tool' tool '-query <args>'
   endif
 endfor
+
+augroup grepper
+  au!
+  autocmd FileType qf call grepper#on_qf()
+augroup END

--- a/test/feature/flags.vader
+++ b/test/feature/flags.vader
@@ -6,7 +6,7 @@ Execute (:Grepper -noprompt -tool ag -grepprg ag --column --nogroup -s Foo inclu
   Grepper -noprompt -tool ag -grepprg ag --column --nogroup -s Foo include
   AssertEqual len(getqflist()), 1
   AssertEqual winnr('$'), 2
-  AssertEqual w:quickfix_title, 'ag --column --nogroup -s Foo include '
+  AssertEqual w:quickfix_title, 'ag --column --nogroup -s Foo include  [grepper]'
   AssertEqual getline('.')[:6], 'include'
 
 Execute (:Grepper -noprompt -noswitch -tool ag -grepprg ag --column --nogroup -s Foo include):


### PR DESCRIPTION
This uses the new `title` argument with `setqflist`/`setloclist`, if
available to set the title with a suffix that allows to handle it via
a `FileType qf` autocommand later, too.

With this the qf windows will have mappings and title always (with
`-noopen` and after `:cclose/:copen`).

Fixes https://github.com/mhinz/vim-grepper/issues/40.