### PR TITLE
Use explicit winnr with O mapping

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -455,6 +455,7 @@ function! s:finish_up(flags) abort
     nnoremap <silent><buffer> <cr> <cr>zv
     nnoremap <silent><buffer> o    <cr>zv
     nnoremap <silent><buffer> O    <cr>zv<c-w>p
+    nnoremap <silent><buffer> O    :let w=winnr()<cr><cr>zv:exec w 'wincmd p'<cr>
     nnoremap <silent><buffer> s    :call <sid>open_entry('split',  1)<cr>
     nnoremap <silent><buffer> S    :call <sid>open_entry('split',  0)<cr>
     nnoremap <silent><buffer> v    :call <sid>open_entry('vsplit', 1)<cr>


### PR DESCRIPTION
With autocommands etc you might not end up in the previous/qf window
otherwise.