### PR TITLE
Ignore tags files generated by :Helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
It would be great if you added `/doc/tags` to your .gitignore file. For
some context, here's an exerpt from Shougo/neocomplete.vim#125:

> `@nikital` writes:
>
> Adding this ignore file is common for Vim plugins that have
> documentation with it. It is useful for people who use a manager like
> Pathogen, have their vim configuration committed into Git, and use Git
> submodules to manage their plugins. (For an example have a look at
> https://github.com/nikital/dotfiles/tree/master/vim/bundle).
>
> After installing a new plugin as a submodule, I usually run :Helptags
> inside Vim to generate tags for the new documentation. As a result a
> tags file is created in doc/tags for each plugin, but since most
> plugins have a gitignore for tags, the new file doesn't cause any
> problems. When a plugin doesn't have a gitignore it starts showing up
> as modified in git status and causes annoyances for actions such as
> pulling a new version of the submodule.
>
> A lot of plugins add this ignore: unite, neocomplcache, neosnippet,
> fugitive, surround, emmet, vim-rails, tcomment and 99% of all plugins
> I ever came across.