### PR TITLE
Redraw just before echo in finish_up

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -443,10 +443,9 @@ function! s:finish_up(flags) abort
     endif
   endif
 
-  redraw
-
   if size == 0
     execute (qf ? 'cclose' : 'lclose')
+    redraw
     echo 'No matches found.'
     return
   endif
@@ -465,6 +464,7 @@ function! s:finish_up(flags) abort
     endif
   endif
 
+  redraw
   echo printf('Found %d matches.', size)
   
   if exists('#User#Grepper')


### PR DESCRIPTION
Otherwise the "Found x matches." message might not be visible with the
following command:

    nvim --cmd 'let loaded_startify=1' -c 'Grepper -noprompt -tool ag -jump -noopen -query foo'