### PR TITLE
doc/faq: remove 'git -C `...`' style example

### DIFF
--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -275,11 +275,6 @@ directory, consider replacing the default |'grepprg'| for git like this:
     let g:grepper.git =
       \ { 'grepprg': 'git grep -nI $* -- `git rev-parse --show-toplevel`' }
 <
-Alternatively, if you're using a recent enough git version, this works too:
->
-    let g:grepper.git =
-      \ { 'grepprg': 'git -C `git rev-parse --show-toplevel` grep -nI' }
-<
 ------------------------------------------------------------------------------
                                                                 *grepper-faq-02*
 How to change the colors of the quickfix window?~


### PR DESCRIPTION
It does not really work as expected.

Since the git command is launched from the root and not the current vim directory, it is impossible to jump to match results if vim was not launched at the root.