### PR TITLE
Do not use :silent when jumping

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -479,7 +479,7 @@ function! s:finish_up(flags)
   endif
 
   if a:flags.jump
-    execute 'silent' (qf ? 'cfirst' : 'lfirst')
+    execute (qf ? 'cfirst' : 'lfirst')
   endif
 
   " Also open if the list contains any invalid entry.


### PR DESCRIPTION
This will silence/suppress a "file has changed" warning (W11) when using
'noautoread'!
The file will not be loaded, and therefore you might edit an outdated
version.

This was added in 5d6d490, without further explanation.