### PR TITLE
Set stdin to null for Vim async jobs

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -478,6 +478,7 @@ function! s:run(flags)
       silent! call job_stop(s:id)
     endif
     let s:id = job_start(cmd, {
+          \ 'in_io':    'null',
           \ 'err_io':   'out',
           \ 'out_cb':   function('s:on_stdout_vim', options),
           \ 'close_cb': function('s:on_exit', options),


### PR DESCRIPTION
This helps with tools that try to detect whether stdin is a pipe so they can automatically search stdin instead of the filesystem.  With Vim's async job system, such tools may incorrectly guess that stdin is a pipe unless ``in_io`` is set to ``null``.

I was seeing problems on Ubuntu 14.04 with a self-compiled gvim when using the Silver Searcher.  As with the other tools mentioned in #65, the ``ag`` command was hanging, trying to search stdin.  This patch fixes the issue for me by having Vim expressly connect stdin to /dev/null.  It also eliminates the need for the [work-around](https://github.com/mhinz/vim-grepper/blob/master/autoload/grepper.vim#L476) that avoids asynchronous execution for ack, pt, and rg, at least in my limited testing of those tools, but I didn't remove that work-around in this patch because I don't know what other reasons you might have for needing it.