### PR TITLE
Do not launch a search with an empty query

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -136,7 +136,7 @@ endfunction
 " #complete() {{{2
 function! grepper#complete(lead, line, _pos) abort
   if a:lead =~ '^-'
-    let flags = ['-buffer', '-buffers', '-cword', '-grepprg', '-highlight',
+    let flags = ['-buffer', '-buffers', '-cword', '-dir', '-grepprg', '-highlight',
           \ '-jump', '-open', '-prompt', '-query', '-quickfix', '-side',
           \ '-switch', '-tool', '-nohighlight', '-nojump', '-noopen',
           \ '-noprompt', '-noquickfix', '-noswitch']

--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -277,6 +277,17 @@ function! s:unescape_query(flags, query)
   return q
 endfunction
 
+" s:cword_query() {{{2
+function! s:cword_query(flags)
+  let w = expand('<cword>')
+
+  if empty(w)
+    return ''
+  endif
+
+  return s:escape_query(a:flags, w)
+endfunction
+
 " s:change_working_directory() {{{2
 function! s:change_working_directory(dirflag) abort
   for dir in split(a:dirflag, ',')
@@ -397,16 +408,20 @@ function! s:process_flags(flags)
   endif
 
   if a:flags.cword
-    let a:flags.query = s:escape_query(a:flags, expand('<cword>'))
+    let a:flags.query = s:cword_query(a:flags)
   endif
 
   if a:flags.prompt
     call s:prompt(a:flags)
     if empty(a:flags.query)
-      let a:flags.query = s:escape_query(a:flags, expand('<cword>'))
+      let a:flags.query = s:cword_query(a:flags)
     elseif a:flags.query =~# s:magic.esc
       return
     endif
+  endif
+
+  if empty(a:flags.query)
+    return 1
   endif
 
   if a:flags.side


### PR DESCRIPTION
It happens if `<cword>` is expanded while the cursor is on an empty line.

This causes the grep tool to match every lines of every file which is usually not what the user want and can be very slow.

I also added the new `-dir` option to the completion list.