### PR TITLE
Removed <esc> binding to avoid issues with terminal arrow keys

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -450,7 +450,6 @@ function! s:prompt(flags)
 
   let mapping = maparg(g:grepper.next_tool, 'c', '', 1)
   execute 'cnoremap' g:grepper.next_tool s:magic.next .'<cr>'
-  execute 'cnoremap <esc>' s:magic.esc .'<cr>'
   echohl Question
   call inputsave()
 
@@ -460,7 +459,6 @@ function! s:prompt(flags)
   finally
     execute 'cunmap' g:grepper.next_tool
     call inputrestore()
-    cunmap <esc>
     call s:restore_mapping(mapping)
     echohl NONE
   endtry


### PR DESCRIPTION
Hello, I'm a new vim-grepper user. I'm really liking this project so far, thank you! 😄 

I noticed that arrow keys weren't working properly for me in the `:Grepper` prompt. e.g. when trying to go back through the search history.

It looks like the code to temporarily rebind the `<esc>` key is causing problems. I think it must be because pressing an arrow key sends a sequence of characters including an esc character. This [stackoverflow question](http://stackoverflow.com/questions/11940801/mapping-esc-in-vimrc-causes-bizzare-arrow-behaviour) might be relevant..?

Please consider this PR as a workaround since its just deleting the code—but it seems to fix the problem and the esc key still seems to work ok. I'm probably missing something important though. 😅 

--- 

Some extra info about my vim setup in case it helps:

```
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jan  1 2017 18:13:09)
MacOS X (unix) version
Included patches: 1-134
Compiled by Homebrew
Huge version without GUI.  Features included (+) or not (-):
+acl             +file_in_path    +mouse_sgr       +tag_old_static
+arabic          +find_in_path    -mouse_sysmouse  -tag_any_white
+autocmd         +float           +mouse_urxvt     -tcl
-balloon_eval    +folding         +mouse_xterm     +termguicolors
-browse          -footer          +multi_byte      +terminfo
++builtin_terms  +fork()          +multi_lang      +termresponse
+byte_offset     -gettext         -mzscheme        +textobjects
+channel         -hangul_input    +netbeans_intg   +timers
+cindent         +iconv           +num64           +title
-clientserver    +insert_expand   +packages        -toolbar
+clipboard       +job             +path_extra      +user_commands
+cmdline_compl   +jumplist        +perl            +vertsplit
+cmdline_hist    +keymap          +persistent_undo +virtualedit
+cmdline_info    +lambda          +postscript      +visual
+comments        +langmap         +printer         +visualextra
+conceal         +libcall         +profile         +viminfo
+cryptv          +linebreak       +python          +vreplace
+cscope          +lispindent      -python3         +wildignore
+cursorbind      +listcmds        +quickfix        +wildmenu
+cursorshape     +localmap        +reltime         +windows
+dialog_con      -lua             +rightleft       +writebackup
+diff            +menu            +ruby            -X11
+digraphs        +mksession       +scrollbind      -xfontset
-dnd             +modify_fname    +signs           -xim
-ebcdic          +mouse           +smartindent     -xpm
+emacs_tags      -mouseshape      +startuptime     -xsmp
+eval            +mouse_dec       +statusline      -xterm_clipboard
+ex_extra        -mouse_gpm       -sun_workshop    -xterm_save
+extra_search    -mouse_jsbterm   +syntax
+farsi           +mouse_netterm   +tag_binary
   system vimrc file: "$VIM/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
  fall-back for $VIM: "/usr/local/share/vim"
Compilation: clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X_UNIX  -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
Linking: clang   -L. -L/usr/local/lib  -L/usr/local/lib -o vim        -lm  -lncurses -liconv -framework Cocoa   -fstack-protector -L/usr/local/lib  -L/System/Library/Perl/5.16/darwin-thread-multi-2level/CORE -lperl -F/usr/local/Cellar/python/2.7.11/Frameworks -framework Python   -lruby.2.0.0 -lobjc
```

I'm using iTerm2 for my terminal.