### PR TITLE
Added quickfix/location window shortcuts

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -590,6 +590,17 @@ function! s:finish_up(flags)
   redraw
   echo printf('Found %d matches.', size)
 
+  nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
+  nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
+  nnoremap <silent> <buffer> o  <CR>
+  nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
+  nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
+  nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
+
+  exe 'nnoremap <silent> <buffer> e <CR><C-w><C-w>:' . ( qf ? 'c' : 'l' ) .'close<CR>'
+  exe 'nnoremap <silent> <buffer> go <CR>:' . ( qf ? 'c' : 'l' ) . 'open<CR>'
+  exe 'nnoremap <silent> <buffer> q  :' . ( qf ? 'c' : 'l' ) . 'close<CR>'
+
   if a:flags.side
     call s:side(a:flags.quickfix)
   endif

--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -328,6 +328,22 @@ dedicated plugins:
     - https://github.com/yssl/QFEnter
     - https://github.com/romainl/vim-qf
 
+Quickfix/Location Window:~
+
+In the quickfix/location window, you can use:
+
+    e    to open file and close the quickfix/location window
+    o    to open (same as enter)
+    go   to preview file (open but maintain focus on grepper results)
+    t    to open in new tab
+    T    to open in new tab silently
+    h    to open in horizontal split
+    H    to open in horizontal split silently
+    v    to open in vertical split
+    gv   to open in vertical split silently
+    q    to close the quickfix/location window
+
+
 ==============================================================================
 OPERATOR                                                      *grepper-operator*
 


### PR DESCRIPTION
## About this PR

When the user is navigating into the quickfix/location result window, it`s possible to 
use the following shortcuts for some common useful actions.

## Shortcuts

```
 e    to open file and close the quickfix/location window
 o    to open (same as enter)
 go   to preview file (open but maintain focus on grepper results)
 t    to open in new tab
 T    to open in new tab silently
 h    to open in horizontal split
 H    to open in horizontal split silently
 v    to open in vertical split
 gv   to open in vertical split silently
 q    to close the quickfix/location window
```

## Note

You will need to update the Grepper Wiki to list the new shortcuts.