### PR TITLE
Add search status before searching

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -488,6 +488,9 @@ function! s:start(flags) abort
     return
   endif
 
+  redraw
+  echo printf('Grepper %s searching for %s ...', a:flags.tools, a:flags.query)
+
   return s:run(a:flags)
 endfunction
 


### PR DESCRIPTION
This commit adds a search status before searching. This will notify the user that a search has started. Mainly for large project and users that restart searches, it will be a good indicator that Grepper is working.