### PR TITLE
-dir file: do not default on cwd if file is a child

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -336,13 +336,16 @@ function! s:change_working_directory(dirflag) abort
           return
         endif
       endfor
-    elseif dir == 'file'
+    elseif dir == 'filecwd'
       let cwd = getcwd()
       let bufdir = expand('%:p:h')
       if stridx(bufdir, cwd) != 0
         execute 'lcd' fnameescape(bufdir)
         return
       endif
+    elseif dir == 'file'
+      let bufdir = expand('%:p:h')
+      execute 'lcd' fnameescape(bufdir)
     endif
   endfor
 endfunction

--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -147,6 +147,9 @@ won't change back after the search finishes.
     Use the current working directory as reported by |:pwd|.
 
  file~
+    Change to the directory of the current buffer.
+
+ filecwd~
     Change to the directory of the current buffer, but only, if that directory
     isn't below the current working directory already.
 


### PR DESCRIPTION
The current `-dir file` tries to guess what the user wants by using the current working directory if the edited file is inside its hierarchy.

However the "dumb" version, which is to just take the current file's directory, can be useful as well (see: https://github.com/mhinz/vim-grepper/issues/83#issuecomment-290129924).

So that things don't become too confusing, the old behavior is renamed to `filecwd` and the `file` flag now uses the dumb algorithm.

This change will probably break existing configurations which use `-dir file`.