### PR TITLE
Restore original directory when using `-dir`

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -129,7 +129,13 @@ function! s:on_stdout_nvim(_job_id, data, _event) dict abort
     endif
     if self.flags.stop > 0
       let nmatches = len(self.flags.quickfix ? getqflist() : getloclist(0))
-      if nmatches >= self.flags.stop || len(self.stdoutbuf) >= self.flags.stop
+      if nmatches >= self.flags.stop || len(self.stdoutbuf) > self.flags.stop
+        " Add the remaining data
+        let n_rem_lines = self.flags.stop - nmatches - 1
+        if n_rem_lines > 0
+          noautocmd execute self.addexpr 'self.stdoutbuf[:n_rem_lines]'
+        endif
+
         call jobstop(s:id)
         unlet s:id
       endif

--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -113,13 +113,13 @@ function! s:on_stdout_nvim(_job_id, data, _event) dict abort
   try
     if empty(a:data[-1])
       " Second-last item is the last complete line in a:data.
-      execute self.addexpr 'self.stdoutbuf + a:data[:-2]'
+      noautocmd execute self.addexpr 'self.stdoutbuf + a:data[:-2]'
       let self.stdoutbuf = []
     else
       if empty(self.stdoutbuf)
         " Last item in a:data is an incomplete line. Put into buffer.
         let self.stdoutbuf = [remove(a:data, -1)]
-        execute self.addexpr 'a:data'
+        noautocmd execute self.addexpr 'a:data'
       else
         " Last item in a:data is an incomplete line. Append to buffer.
         let self.stdoutbuf = self.stdoutbuf[:-2]
@@ -148,7 +148,7 @@ function! s:on_stdout_vim(_job_id, data) dict abort
   let orig_dir = s:chdir_push(self.cmd_dir)
 
   try
-    execute self.addexpr 'a:data'
+    noautocmd execute self.addexpr 'a:data'
     if self.flags.stop > 0
           \ && len(self.flags.quickfix ? getqflist() : getloclist(0)) >= self.flags.stop
       call job_stop(s:id)

--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -211,11 +211,6 @@ Chances are, if you have more than 5000 matches, you executed Grepper in a
 place with too many subdirectories or your search query was too general or
 both. This limits the impact of otherwise long-running processes.
 
-NOTE: In Vim, the stdout callback works line-by-line and Grepper will stop the
-search at the exact number of matches. In Neovim, it most probably won't be
-the exact number. For the sake of improving performance, Neovim (or rather the
-underlying libuv) does batch processing of the grep tools' output.
-
 ==============================================================================
 COMMANDS                                                      *grepper-:Grepper*
 >


### PR DESCRIPTION
First part of #108 (also discussed in #83).

To handle this, the simplest way is to temporarily change the directory during each addition to the quickfix/local list. To limit the potential impacts, no switch is done in the default `cwd` mode.

I had an issue with vim-qf, only on mainline vim, which was odd. Apparently it was caused by the 7.4.2299 patch which was not back-ported in the neovim version I used for the tests (found [this](https://github.com/wincent/ferret/issues/30) after a google search).

I did not use the `cwd` option for `jobstart()` on neovim for consistency with other versions.