### PR TITLE
Add quotes around search query

### DIFF
--- a/autoload/grepper.vim
+++ b/autoload/grepper.vim
@@ -629,7 +629,7 @@ function! s:build_cmdline(flags) abort
   if stridx(grepprg, '$*') >= 0
     let grepprg = substitute(grepprg, '\V$*', escape(a:flags.query, '\&'), 'g')
   else
-    let grepprg .= ' ' . a:flags.query
+    let grepprg .= ' "' . a:flags.query . '"'
   endif
 
   return grepprg


### PR DESCRIPTION
This PR adds quotes around a search query, to make it easier to grep on strings that contain spaces.

Without them, you have to enter the quotes yourself, and if you forget, you get a bunch of error messages.