### PR TITLE
Windows: Use Powershell to perform searches

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -663,8 +663,14 @@ function! s:run(flags)
   let s:cmdline = s:build_cmdline(a:flags)
 
   " 'cmd' and 'options' are only used for async execution.
-  if has('win32') && &shell =~ 'cmd'
+  if ( has('win32') || has("win64")) && &shell =~ 'powershell'
+    " Windows powershell has better quot handling
     let cmd = s:cmdline
+  elseif ( has('win32') || has("win64")) && &shell =~ 'cmd'
+    " Since Windows cmd handles single quotes as part of the query
+    " we spawn a powershell session within cmd to avoid this behavior
+    " Hack took from https://stackoverflow.com/questions/94382/vim-with-powershell
+    let cmd = ['powershell.exe', '-NoLogo','-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned' , s:cmdline]
   else
     let cmd = ['sh', '-c', s:cmdline]
   endif


### PR DESCRIPTION
Improve Windows support

Use powershell, instead of cmd, to perform all searches.