### PR TITLE
Provide g:grepper.prompt_quote default

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -14,6 +14,7 @@ let s:defaults = {
       \ 'cword':         0,
       \ 'prompt':        1,
       \ 'simple_prompt': 0,
+      \ 'prompt_quote':  0,
       \ 'highlight':     0,
       \ 'buffer':        0,
       \ 'buffers':       0,


### PR DESCRIPTION
I was getting the following error and providing a default fixes the issue. I've pretty much never written vimscript so please feel free to shoot me down if this is not what is needed as a fix. 

```
Error detected while processing function <SNR>51_parse_flags[74]..<SNR>51_start[6]..<SNR>51_process_flags:
line   48:
E716: Key not present in Dictionary: prompt_quote
E15: Invalid expression: a:flags.prompt_quote
```