### PR TITLE
nvim: use buffered output

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -755,6 +755,8 @@ function! s:run(flags)
       let s:id = jobstart(cmd, extend(options, {
             \ 'on_stdout': function('s:on_stdout_nvim'),
             \ 'on_stderr': function('s:on_stdout_nvim'),
+            \ 'stdout_buffered': 1,
+            \ 'stderr_buffered': 1,
             \ 'on_exit':   function('s:on_exit'),
             \ }))
     finally


### PR DESCRIPTION
This is available with nvim-0.2.3.

It could use a specialized callback / the result stored in options, but
seems to work as-is for now.

This improves performance a lot in case there is a lot of output, e.g.
~1MB because of multiple matches in a big JSON file.
In the case at hand it produced ~50 matches, with a total output of
~1MB, taking more than 30s to process:

```
FUNCTIONS SORTED ON TOTAL TIME
count  total (s)   self (s)  function
 1134  31.929303  31.907790  <SNR>140_on_stdout_nvim()

FUNCTION  <SNR>140_on_stdout_nvim()
Called 1134 times
Total time:  31.929303
 Self time:  31.907790

count  total (s)   self (s)
 1134              0.004128   if !exists('s:id')
                                return
                              endif

 1134   0.165982   0.144469   let cmd_cdback = s:chdir_push(self.cmd_dir)

 1134              0.001747   try
 1134              0.018892     if empty(a:data[-1])
                                  " Second-last item is the last complete line in a:data.
    7              0.031250       noautocmd execute self.addexpr 'self.stdoutbuf + a:data[:-2]'
    7              0.000826       let self.stdoutbuf = []
    7              0.000016     else
 1127              0.002460       if empty(self.stdoutbuf)
                                    " Last item in a:data is an incomplete line. Put into buffer.
    1              0.000009         let self.stdoutbuf = [remove(a:data, -1)]
    1              0.000026         noautocmd execute self.addexpr 'a:data'
    1              0.000001       else
                                    " Last item in a:data is an incomplete line. Append to buffer.
 1126             31.593586         let self.stdoutbuf = self.stdoutbuf[:-2] + [self.stdoutbuf[-1] . get(a:data, 0, '')] + a:data[1:]
 1126              0.004912       endif
 1127              0.000983     endif
 1134              0.004899     if self.flags.stop > 0
 1134              0.029810       let nmatches = len(self.flags.quickfix ? getqflist() : getloclist(0))
 1134              0.004931       if nmatches >= self.flags.stop || len(self.stdoutbuf) > self.flags.stop
                                    " Add the remaining data
                                    let n_rem_lines = self.flags.stop - nmatches - 1
                                    if n_rem_lines > 0
                                      noautocmd execute self.addexpr 'self.stdoutbuf[:n_rem_lines]'
                                    endif

                                    call jobstop(s:id)
                                    unlet s:id
                                  endif
 1134              0.000808     endif
 1134              0.001363   finally
 1134              0.003606     execute cmd_cdback
 1134              0.001353   endtry

```