### PR TITLE
Prefer ack-grep rather than ack

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -123,11 +123,12 @@ endif
 
 "
 " Special case: ack (different distros use different names for ack)
+" Prefer ack-grep since its presence likely means ack is a different tool.
 "
 let s:ack     = index(g:grepper.tools, 'ack')
 let s:ackgrep = index(g:grepper.tools, 'ack-grep')
 if (s:ack >= 0) && (s:ackgrep >= 0)
-  call remove(g:grepper.tools, s:ackgrep)
+  call remove(g:grepper.tools, s:ack)
 endif
 
 let s:cmdline = ''


### PR DESCRIPTION
If ack-grep is present on the system, then that likely means ack refers
to a different tool.  Therefore ack-grep, not ack, should be maintained
in the tool list.