### PR TITLE
[RFC] highlight: remove any flags from query

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -854,7 +854,13 @@ endfunction
 " -highlight {{{1
 " s:highlight_query() {{{2
 function! s:highlight_query(flags)
-  let query = has_key(a:flags, 'query_orig') ? a:flags.query_orig : a:flags.query
+  if has_key(a:flags, 'query_orig')
+    let query = a:flags.query_orig
+  else
+    " Remove any flags at the beginning, e.g. when using '-uu' with rg, but
+    " keep plain '-'.
+    let query = substitute(a:flags.query, '\v-\w+\s+', '', 'g')
+  endif
 
   " Change Vim's '\'' to ' so it can be understood by /.
   let vim_query = substitute(query, "'\\\\''", "'", 'g')


### PR DESCRIPTION
When using `:Grepper -tool rg` with a query like `-uu foo` (via the
prompt) to also search hidden files, the `-uu` should not be included in
the highlighted query.

This might get changed to be smarter, e.g. to only consider the first
word, e.g. with "-uu foo dir" only "foo" is the pattern, but it would
need to handle "-uu 'foo bar' dir" also.