### PR TITLE
Prevent disappearing cursor when "No matches found."

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -819,6 +819,7 @@ function! s:finish_up(flags)
     execute (qf ? 'cclose' : 'lclose')
     redraw
     echo 'No matches found.'
+    call s:redraw_cursor()
     return
   endif
 
@@ -1075,7 +1076,14 @@ function! s:operator(type) abort
   return s:start(flags)
 endfunction
 
+" Redraw Cursor {{{1
+function! s:redraw_cursor() abort
+  " counteract disappearing cursor caused by :echo
+  call feedkeys("\<plug>(GrepperNop)")
+endfunction
+
 " Mappings {{{1
+nnoremap <silent> <plug>(GrepperNop)      <nop>
 nnoremap <silent> <plug>(GrepperOperator) :set opfunc=<sid>operator<cr>g@
 xnoremap <silent> <plug>(GrepperOperator) :<c-u>call <sid>operator(visualmode())<cr>
 


### PR DESCRIPTION
When no search results are found, `s:finish_up()` shows a message to that effect:
``` vim
echo 'No matches found.'
```

Unfortunately, this causes the cursor to disappear. This only affects the case where no matches are found -- the other use of `echo` is to report on how many matches were found, but this coincides with moving the cursor to the results list (quickfix/location-list), and there's no disappearing cursor.

This "fix" feels more like a workaround, but after sprinkling numerous redraws around the affected code, it's the only solution I could come up with, and seems pretty benign.

To repro the bug this addresses:
``` sh
git clone git@github.com:mhinz/vim-grepper.git
cd vim-grepper
vim -u NONE --clean -c 'source plugin/grepper.vim'
```
Then run:
``` vim
:Grepper
```
and search for something that doesn't exist:
```
> somequerywithnoresults
```

Expected behavior: Display "No matches found." and make cursor reappear in window it occupied when `:Grepper` was run.

Actual behavior: Display "No matches found." and cursor disappears.

This change implements the expected behavior.

Tested on NixOS. I will also verify on Ubuntu and macOS. I don't have access to a Windows machine (thank god).
```
vim --version
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jan  1 1970 00:00:01)
Included patches: 1-1451
```