### PR TITLE
Idempotent Loading

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -1,5 +1,10 @@
 " Initialization {{{1
 
+if exists('g:loaded_grepper')
+  finish
+endif
+let g:loaded_grepper = 1
+
 " Escaping test line:
 " ..ad\\f40+$':-# @=,!;%^&&*()_{}/ /4304\'""?`9$343%$ ^adfadf[ad)[(
 


### PR DESCRIPTION
Add a guard-clause to avoid double-loading the plugin.

I was developing an unrelated feature and working on a copy of the plugin I had symlinked early in my `'runtimepath'`. Vim was loading both my development copy and the master copy, since there was no such guard-clause in place.