### PR TITLE
Store Search Pattern in List Context

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -806,11 +806,11 @@ function! s:finish_up(flags)
   call s:restore_errorformat()
 
   try
-    let title = has('nvim') ? cmdline : {'title': cmdline}
+    let attrs = has('nvim') ? cmdline : {'title': cmdline, 'context': @/}
     if qf
-      call setqflist(list, a:flags.append ? 'a' : 'r', title)
+      call setqflist(list, a:flags.append ? 'a' : 'r', attrs)
     else
-      call setloclist(0, list, a:flags.append ? 'a' : 'r', title)
+      call setloclist(0, list, a:flags.append ? 'a' : 'r', attrs)
     endif
   catch /E118/
   endtry


### PR DESCRIPTION
Store the search pattern in the resulting list's "context" attribute.

This enables later retrieval, which is useful if you want to re-apply the corresponding search highlighting after running `:cnewer` or `:colder`.

For example,
``` vim
func! Cnewer()
  cnewer
  let pattern = getqflist({'context': 0}).context
  if !empty(pattern) | let @/ = pattern | endif
endf
```

I'm doing [something along these lines](https://github.com/ivanbrennan/listical/commit/e1dfe06907eb54a238708d2c416461f93facfff2) in a plugin I use to navigate/manipulate the quickfix list.