### PR TITLE
Fix Ag version check

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -127,7 +127,7 @@ endfor
 "
 if index(g:grepper.tools, 'ag') >= 0
       \ && !exists('g:grepper.ag.grepprg')
-      \ && split(system('ag --version'))[2] =~ '^\v\d+\.%([01]|2[0-4])'
+      \ && split(system('ag --version'))[2] =~ '^\v0\.%([01]|2[0-4])'
   let g:grepper.ag.grepprg = 'ag --column --nogroup'
 endif
 


### PR DESCRIPTION
A version check intended to detect Ag versions < 0.25 was matching all minor versions < 25 regardless of major version. So 2.1.0 was matched, for example.