### PR TITLE
List context: store 'query' (@/) in dictionary

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -805,7 +805,7 @@ function! s:finish_up(flags)
     " TODO: Remove condition if nvim 0.2.0+ enters Debian stable.
     let attrs = has('nvim') && !has('nvim-0.2.0')
           \ ? cmdline
-          \ : {'title': cmdline, 'context': @/}
+          \ : {'title': cmdline, 'context': {'query': @/}}
     if qf
       call setqflist(list, a:flags.append ? 'a' : 'r', attrs)
     else


### PR DESCRIPTION
Storing this info in a dictionary allows for greater flexibility if other tools want to interact with the context.