### PR TITLE
Fix s:highlight_query: only use query for @/

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -862,10 +862,30 @@ function! s:highlight_query(flags)
 
   " Remove surrounding quotes that denote a string.
   let start = vim_query[0]
-  let end = vim_query[-1:-1]
-  if start == end && start =~ "\['\"]"
-    let vim_query = vim_query[1:-2]
+  if start ==# '"' || start ==# "'"
+    let offset = 1
+    while 1
+      let end = stridx(vim_query, start, offset)
+      if end == -1
+        break
+      endif
+      if vim_query[end-1] != '\'
+        break
+      endif
+      let offset = end + 1
+    endwhile
+    if end != -1
+      let vim_query = vim_query[1:end-1]
+    endif
+  else
+    " Use first WORD (with escaped whitespace).
+    let vim_query = matchstr(vim_query, '\v^%(\\\s|\S)+')
   endif
+
+  " Unescape (removing backslashes).
+  let vim_query = substitute(vim_query, '\\"', '"', 'g')
+  let vim_query = substitute(vim_query, '\\''', "'", 'g')
+  let vim_query = substitute(vim_query, '\v\\(\s)', '\1', 'g')
 
   if a:flags.query_escaped
     let vim_query = s:unescape_query(a:flags, vim_query)

--- a/test/feature/vim_query.vader
+++ b/test/feature/vim_query.vader
@@ -1,0 +1,41 @@
+Before:
+  enew!
+  only!
+  let w:testing = 1
+
+  " Remove . from grepprg to pick up include only (see #162).
+  Save g:grepper
+  let g:grepper.grep.grepprg = 'grep -RIn $*'
+
+Execute (Does not change @/ by default):
+  Save @/
+  let @/ = 'orig_query'
+  Grepper -noprompt -tool grep -query Foo include
+  AssertEqual @/, 'orig_query'
+  AssertEqual map(getqflist(), 'v:val.text'), ['Foo: This is just a random']
+
+Execute (Simple vim_query):
+  Save @/
+  Log g:grepper.grep
+  Grepper -noprompt -tool grep -highlight -query Foo include
+  AssertEqual @/, 'Foo'
+  AssertEqual map(getqflist(), 'v:val.text'), ['Foo: This is just a random']
+
+Execute (Complex vim_query):
+  Save @/
+  Grepper -noprompt -tool grep -highlight -query "Something \"quoted" include
+  AssertEqual @/, 'Something "quoted'
+  AssertEqual map(getqflist(), 'v:val.lnum'), [7]
+
+Execute (Complex vim_query with leading escaped double quote):
+  Save @/
+  Grepper -noprompt -tool grep -highlight -query \"quoted include
+  AssertEqual @/, '"quoted'
+  AssertEqual map(getqflist(), 'v:val.lnum'), [7]
+
+Execute (Complex vim_query with single quotes):
+  Save @/
+  Grepper -noprompt -tool grep -highlight -query \'inline\ quotes\' include
+  AssertEqual w:quickfix_title, 'grep -RIn \''inline\ quotes\'' include'
+  AssertEqual @/, "'inline quotes'"
+  AssertEqual map(getqflist(), 'v:val.lnum'), [7]

--- a/test/include/test.txt
+++ b/test/include/test.txt
@@ -3,3 +3,5 @@ plain text file that is used
 for, well, testing purposes.
 
 foo bar quux
+
+Something "quoted with 'inline quotes'" and "escaped \" quotes"


### PR DESCRIPTION
When using `:Grepper -tool rg` and entering `foo tests` to search for
"foo" in tests/ it would use "foo tests" for `@/`, but it should be only
"foo".

This patch fixes this, and also handles `"foo \"" dir` correctly.