### PR TITLE
Speed up asynchronous Vim searches (Nvim unchanged).

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -189,8 +189,8 @@ function! s:on_stdout_vim(_job_id, data) dict abort
 
   try
     noautocmd execute self.addexpr 'a:data'
-    if self.flags.stop > 0
-          \ && len(self.flags.quickfix ? getqflist() : getloclist(0)) >= self.flags.stop
+    let self.num_matches += 1
+    if self.flags.stop > 0 && self.num_matches >= self.flags.stop
       call job_stop(s:id)
       unlet s:id
     endif
@@ -744,6 +744,7 @@ function! s:run(flags)
         \ 'window':    winnr(),
         \ 'tabpage':   tabpagenr(),
         \ 'stdoutbuf': [],
+        \ 'num_matches': 0,
         \ }
 
   call s:store_errorformat(a:flags)


### PR DESCRIPTION
This pull request addresses the speed issues in #174; the
commit log is below.

Grepper's "stop" feature aborts a search when it passes a threshold
number of matches.  Previously, the number of matches was determined by
the expression ``len(getqflist())`` (or ``len(getloclist(0))``) which
was evaluated upon the arrival of every line of search results.  Vim's
``getqflist()`` function appears to take around a constant amount of
time per line in the list (around 1 millisecond per line on the author's
4 GHz i7 machine), so the time scales linearly with the length of the
list.  Overall, this makes for quadratic time complexity to add all of
the search results.

This patch adds the variable ``num_matches`` to track the number of
matching lines as they are added to the QuickFix list, eliminating the
need to call ``getqflist()`` at the arrival of every line and bringing
the time for asynchronous searches back into line with that of
synchronous searches.

For example, for a particular set of files on the author's computer
(described below), the following times were observed when limiting
``g:grepper.size`` as shown:

Using ``len(getqflist())`` on each line:

  size    time

  2000    2.5 seconds
  5000    11 seconds
  10000   50 seconds

After patching, the times all drop to values too short to accurately
measure with a simple watch:

Using ``num_matches`` comparison on each line:

  size    time

  2000    < 1 second
  5000    < 1 second
  10000   < 1 second

For a more measurable test, the search pattern was changed to a single
character, yielding 152,490 matching lines.  Search times shown below
indicate that even for a very large number of matches, the incremental
asynchronous approach is on par with synchronous searches (forced by
setting ``w:testing`` before the search):

  Search type              time for 152,490 matches

  synchronous              5.5 seconds
  async, size=0            7 seconds
  async, size=5000000      7 seconds

For reference, the tree of test files consisted of 211 files totaling
256 thousand lines (14 million bytes).

Note that this changes applies only to the Vim asynchronous searching,
at the author doesn't use Neovim; however, a similar comparison is done
for Neovim in the Grepper source.  If there is a similar bottleneck for
Neovim, it would probably be worth making comparable changes to that
portion of the source