### PR TITLE
[RFC] Make -query not imply -noprompt

### DIFF
--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -363,7 +363,7 @@ Populate the prompt with the word under cursor.
                                                                 *:Grepper-query*  >
     -query <query>
 <
-Search using this query. This implies `-noprompt`.
+Search using this query.
 
 This is NOT meant for adding options to the tool. See |grepper-faq-05|.
 
@@ -692,7 +692,7 @@ This is a possible configuration..
     let g:grepper.jump      = 1
     let g:grepper.next_tool = '<leader>g'
 
-    command! Todo Grepper -tool git -query -E '(TODO|FIXME|XXX):'
+    command! Todo Grepper -noprompt -tool git -query -E '(TODO|FIXME|XXX):'
 <
 ==============================================================================
 vim: tw=78

--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -502,7 +502,6 @@ function! s:parse_flags(args) abort
         " ..thus you get nicer file completion.
       else
         let flags.query = args
-        let flags.prompt = 0
       endif
       break
     elseif flag =~? '^-tool$'


### PR DESCRIPTION
Honestly I can't remember the rationale behind the original decision, but now it
is possible to pre-populate the query _without_ searching right away.

This is especially useful if you want to build your own commands. E.g. a query
for Markdown could be pre-populated with a regexp that matches only headers.