### PR TITLE
Display message when running command

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -818,6 +818,8 @@ function! s:run(flags)
     echomsg 'grepper: running' string(cmd)
   endif
 
+  echo printf('Running: %s', s:cmdline)
+
   if has('nvim')
     if exists('s:id')
       silent! call jobstop(s:id)


### PR DESCRIPTION
This PR displays a message when running a command. This is especially useful when running queries that take several seconds to complete as the current lack of indication can leave the user wondering if the command is indeed being executed in the background.