### PR TITLE
Support configurable prompt suffix

### DIFF
--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -80,6 +80,7 @@ All options:~
     |g:grepper.jump|
     |g:grepper.prompt|
     |g:grepper.prompt_quote|
+    |g:grepper.prompt_suffix|
     |g:grepper.dir|
     |g:grepper.repo|
     |g:grepper.simple_prompt|
@@ -166,6 +167,17 @@ The following values are available:
   1    Quote the query automatically.
   2    Populate the prompt with single quotes and put cursor in between.
   3    Populate the prompt with double quotes and put cursor in between.
+
+------------------------------------------------------------------------------
+                                                       *g:grepper.prompt_suffix*  >
+    let g:grepper.prompt_suffix = '>'
+<
+Specifies the string to append when displaying the prompt.
+
+To mimic the actual command-line when entering a query, put this in your vimrc:
+>
+    let g:grepper.prompt_suffix = ''
+<
 
 ------------------------------------------------------------------------------
                                                                  *g:grepper.dir*  >

--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -22,6 +22,7 @@ let s:defaults = {
       \ 'prompt':        1,
       \ 'simple_prompt': 0,
       \ 'prompt_quote':  0,
+      \ 'prompt_suffix': '>',
       \ 'highlight':     0,
       \ 'buffer':        0,
       \ 'buffers':       0,
@@ -710,8 +711,8 @@ function! s:prompt(flags)
   call inputsave()
 
   try
-    let a:flags.query = input(prompt_text .'> ', a:flags.query,
-          \ 'customlist,grepper#complete_files')
+    let a:flags.query = input(printf('%s%s ', prompt_text, g:grepper.prompt_suffix),
+          \ a:flags.query, 'customlist,grepper#complete_files')
   finally
     redraw!
 


### PR DESCRIPTION
This PR adds support for a configurable prompt suffix. I've found that having `:Grepper` display the command without the `>` character appended feels more natural. This option allows one to specify another character to suffix the prompt if desired. The original behavior is left intact and example usage has been added to `doc/grepper.txt`.