### PR TITLE
Keep search history with highlighting disabled

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -632,9 +632,7 @@ function! s:process_flags(flags)
     let a:flags.open      = 0
   endif
 
-  if a:flags.highlight
-    call s:highlight_query(a:flags)
-  endif
+  call s:search_query(a:flags)
 
   return 0
 endfunction
@@ -926,9 +924,9 @@ endfunction
 
 " }}}1
 
-" -highlight {{{1
-" s:highlight_query() {{{2
-function! s:highlight_query(flags)
+" -search {{{1
+" s:search_query() {{{2
+function! s:search_query(flags)
   if has_key(a:flags, 'query_orig')
     let query = a:flags.query_orig
   else
@@ -971,7 +969,10 @@ function! s:highlight_query(flags)
 
   let @/ = vim_query
   call histadd('search', vim_query)
-  call feedkeys(":set hls\<bar>echo\<cr>", 'n')
+
+  if a:flags.highlight
+    call feedkeys(":set hls\<bar>echo\<cr>", 'n')
+  endif
 endfunction
 
 " -side {{{1


### PR DESCRIPTION
I came across an interesting side-effect of enabling `g:grepper.highlight` today that I think might be desirable even when highlighting is disabled. Something I find myself doing frequently is when jumping to a file with a match, I prefer to navigate matches using `n`/`N`. Having the search history updated whether or not highlighting is enabled is very useful for me (I normally toggle `hlsearch` if I need a quick visual queue and leave it disabled most of the time).

This PR renames `s:highlight_query` to `s:search_query` and pushes down the conditional to enable highlighting. This ensures search history is always updated, even if highlighting is disabled. 