### PR TITLE
New option: -noside

### DIFF
--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -383,7 +383,7 @@ Overrules |g:grepper.dir|.
 
 ------------------------------------------------------------------------------
                                                                  *:Grepper-side*  >
-    -side
+    -[no]side
 <
 Overrules |g:grepper.side|.
 

--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -215,7 +215,8 @@ function! grepper#complete(lead, line, _pos) abort
     let flags = ['-append', '-buffer', '-buffers', '-cword', '-dir', '-grepprg',
           \ '-highlight', '-jump', '-open', '-prompt', '-query', '-quickfix',
           \ '-side', '-stop', '-switch', '-tool', '-noappend', '-nohighlight',
-          \ '-nojump', '-noopen', '-noprompt', '-noquickfix', '-noswitch']
+          \ '-nojump', '-noopen', '-noprompt', '-noquickfix', '-noside',
+          \ '-noswitch']
     return filter(map(flags, 'v:val." "'), 'v:val[:strlen(a:lead)-1] ==# a:lead')
   elseif a:line =~# '-dir \w*$'
     return filter(map(['cwd', 'file', 'filecwd', 'repo'], 'v:val." "'),
@@ -556,8 +557,8 @@ function! s:parse_flags(args) abort
     elseif flag =~? '\v^-%(no)?buffer$'        | let flags.buffer    = flag !~? '^-no'
     elseif flag =~? '\v^-%(no)?buffers$'       | let flags.buffers   = flag !~? '^-no'
     elseif flag =~? '\v^-%(no)?append$'        | let flags.append    = flag !~? '^-no'
+    elseif flag =~? '\v^-%(no)?side$'          | let flags.side      = flag !~? '^-no'
     elseif flag =~? '^-cword$'                 | let flags.cword     = 1
-    elseif flag =~? '^-side$'                  | let flags.side      = 1
     elseif flag =~? '^-stop$'
       if empty(args) || args[0] =~ '^-'
         let flags.stop = -1


### PR DESCRIPTION
Added -no option to the side option, to enable using side by default,
and running specific commands without it.

Answers issue request from: https://github.com/mhinz/vim-grepper/issues/206

@mhinz - I wrote the fix as you directed me in the issue itself. The only other change I did was to add the [no] option to the documentation as well.

I hope that I did everything according to the project conventions, if I did something wrong, please tell me, and I would gladly fix it.