### PR TITLE
git: grepprg: add --basic-regexp

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -36,7 +36,7 @@ let s:defaults = {
       \ 'prompt_mapping_side': '<c-s>',
       \ 'repo':          ['.git', '.hg', '.svn'],
       \ 'tools':         ['git', 'ag', 'ack', 'ack-grep', 'grep', 'findstr', 'rg', 'pt', 'sift'],
-      \ 'git':           { 'grepprg':    'git grep -nI',
+      \ 'git':           { 'grepprg':    'git grep -nGI',
       \                    'grepformat': '%f:%l:%c:%m,%f:%l:%m',
       \                    'escape':     '\^$.*[]' },
       \ 'ag':            { 'grepprg':    'ag --vimgrep',


### PR DESCRIPTION
While it appears to be smart about e.g. `'{'` alone, it also handles it
in its escaped form.  And escaping e.g. `'+'` is certainly needed.