### PR TITLE
Avoid hit-Enter prompt with "Running: …" message

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -902,7 +902,11 @@ function! s:run(flags)
     echomsg 'grepper: running' string(cmd)
   endif
 
-  echo printf('Running: %s', s:cmdline)
+  let msg = printf('Running: %s', s:cmdline)
+  if exists('v:echospace') && strwidth(msg) > v:echospace
+    let msg = printf('%.*S...', v:echospace - 3, msg)
+  endif
+  echo msg
 
   if has('nvim')
     if exists('s:id')


### PR DESCRIPTION
Without this patch the "echo" might trigger a
"Press ENTER or type command to continue" before running the command.

Ref: https://github.com/neovim/neovim/pull/10845

NOTE: when using the 'highlight' flag (not on by default), the `feedkeys()` for setting hls overwrites/clears it anyway (https://github.com/mhinz/vim-grepper/blob/ebe6d1ffd1fb2faada867c56a55f44cbaa0248e3/plugin/grepper.vim#L710).