### PR TITLE
Pass empty list to setqflist when setting attrs

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -984,9 +984,9 @@ function! s:finish_up(flags)
           \ ? cmdline
           \ : {'title': cmdline, 'context': {'query': @/}}
     if qf
-      call setqflist(list, a:flags.append ? 'a' : 'r', attrs)
+      call setqflist([], a:flags.append ? 'a' : 'r', attrs)
     else
-      call setloclist(0, list, a:flags.append ? 'a' : 'r', attrs)
+      call setloclist(0, [], a:flags.append ? 'a' : 'r', attrs)
     endif
   catch /E118/
   endtry


### PR DESCRIPTION
The 'list' argument is ignored if the 'what' argument is present, and
recently vim has started throwing an error if they are both present and
the list is not empty.

Fixes https://github.com/mhinz/vim-grepper/issues/231