### PR TITLE
Make sure that we don't pipe stdin when starting a job

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -936,6 +936,15 @@ function! s:run(flags)
           \ 'on_stderr': function('s:on_stdout_nvim'),
           \ 'on_exit':   function('s:on_exit'),
           \ }
+    if has('nvim-0.5.1')
+      " Starting with version 13, ripgrep always stats stdin and if it's not a
+      " TTY it uses it to read data. Unfortunately, Neovim always attaches a
+      " pipe to stdin by default and that leads to ripgrep reading nothing...
+      " (see https://github.com/neovim/neovim/pull/14812 for more info)
+      " This was fixed in nvim by adding an option to jobstart to not pipe stdin
+      " (see https://github.com/neovim/neovim/pull/14812).
+      let opts.stdin = 'null'
+    endif
     if !a:flags.stop
       let opts.stdout_buffered = 1
       let opts.stderr_buffered = 1

--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -940,7 +940,7 @@ function! s:run(flags)
       " Starting with version 13, ripgrep always stats stdin and if it's not a
       " TTY it uses it to read data. Unfortunately, Neovim always attaches a
       " pipe to stdin by default and that leads to ripgrep reading nothing...
-      " (see https://github.com/neovim/neovim/pull/14812 for more info)
+      " (see https://github.com/mhinz/vim-grepper/issues/244 for more info)
       " This was fixed in nvim by adding an option to jobstart to not pipe stdin
       " (see https://github.com/neovim/neovim/pull/14812).
       let opts.stdin = 'null'


### PR DESCRIPTION
Starting with version 13, ripgrep always stats stdin and if it's not a TTY it uses it to read data. Unfortunately, Neovim always attaches a pipe to stdin by default and that leads to ripgrep reading nothing and it essentially breaks vim-grepper when targeting a recent version of ripgrep.

(see https://github.com/BurntSushi/ripgrep/issues/1892 for more info)

This was fixed in nvim by adding an option to jobstart to not pipe stdin (see https://github.com/neovim/neovim/pull/14812). So we use this here which I verified fixes search through rg.

Note that I'm not 100% sure how to gate this. It was technically added as a commit to neovim after 0.5 shipped so I imagine it will technically be released in 0.5.1. But it should also be harmless to only gate this to `nvim` since the options are a dictionary and old versions of neovim will just ignore that `stdin` key.

This fixes https://github.com/mhinz/vim-grepper/issues/244