### PR TITLE
Introduce GrepperQuery highlight group

### DIFF
--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -590,7 +590,7 @@ COLORS                                                          *grepper-colors*
 
 Prompt:~
 
-    Default highlight group: GrepperPrompt linked to |hl-Question|.
+    Default highlight group: GrepperPrompt linked to |hl-Question|. To change:
 >
     highlight GrepperPrompt ctermfg=160 guifg=#ff0000 cterm=NONE
 >
@@ -602,7 +602,7 @@ Query:~
 >
 Error messages:~
 
-    Default highlight group: |hl-ErrorMsg|
+    Default highlight group: |hl-ErrorMsg|. To change:
 >
     highlight ErrorMsg ctermfg=160 ctermbg=NONE cterm=NONE
 <

--- a/doc/grepper.txt
+++ b/doc/grepper.txt
@@ -594,6 +594,12 @@ Prompt:~
 >
     highlight GrepperPrompt ctermfg=160 guifg=#ff0000 cterm=NONE
 >
+Query:~
+
+    Default highlight group: GrepperQuery linked to |hl-String|. To change:
+>
+    highlight link GrepperQuery Normal
+>
 Error messages:~
 
     Default highlight group: |hl-ErrorMsg|

--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -9,6 +9,7 @@ let g:loaded_grepper = 1
 " ..ad\\f40+$':-# @=,!;%^&&*()_{}/ /4304\'""?`9$343%$ ^adfadf[ad)[(
 
 highlight default link GrepperPrompt Question
+highlight default link GrepperQuery String
 
 "
 " Default values that get used for missing values in g:grepper.
@@ -804,7 +805,7 @@ function! s:prompt(flags)
             \ 'prompt':     prompt_text,
             \ 'default':    a:flags.query,
             \ 'completion': 'customlist,grepper#complete_files',
-            \ 'highlight':  { cmdline -> [[0, len(cmdline), 'String']] },
+            \ 'highlight':  { cmdline -> [[0, len(cmdline), 'GrepperQuery']] },
             \ })
     else
       let a:flags.query = input(prompt_text, a:flags.query,


### PR DESCRIPTION
The behavior changed in this commit: 8b78347. The decision was to
unconditionally highlight the query like the user's colorscheme highlights
string literals.

I'd like to be able to customize this without changing how all string
literals look, so I've introduced a new `GrepperQuery` highlight group that
links to `String` by default. This means that there should be no change by
default.

I have not written tests for this but I have tested it in my own
configuration files by adding this line:

```vim
hi link GrepperQuery Normal
```

As seen in the diff, there is prior art for introducing new highlighting
groups in grepper already--`GrepperPrompt` is a highlight group that
controls the color of everything before the `>` (which displays the search
program and flags). There do not appear to be any tests for that feature
either, otherwise I would have cargo culted some to test this feature.