### PR TITLE
Do not assume shell for platform

### DIFF
--- a/plugin/grepper.vim
+++ b/plugin/grepper.vim
@@ -899,12 +899,7 @@ function! s:run(flags)
   let s:cmdline = s:build_cmdline(a:flags)
 
   " 'cmd' and 'options' are only used for async execution.
-  if has('win32')
-    let cmd = 'cmd.exe /c '. s:cmdline
-  else
-    let cmd = ['sh', '-c', s:cmdline]
-  endif
-
+  let cmd = [&shell, &shellcmdflag, s:cmdline]
   let options = {
         \ 'cmd':       s:cmdline,
         \ 'work_dir':  s:tmp_work_dir,


### PR DESCRIPTION
win32 does not necessarily mean `cmd.exe` as well as others does not mean `sh`.

Problem is, that previous functions, like s:escape_cword() do respect `shell` e.g.
with `shellescape()`, but passing the arguments to `job_start()` / `jobstart()`
does ignore `shell`.

This leads to trouble. E.g. I use `fish`, where `shellescape()` escapes `\`, which means
if `<cword>` / `-cword` is used (e.g. `Aword`), `s:escape_cword()` results to `\\bAword\\b`
(which is correct), but this string is then passed to `jobstart()` executed by
`sh`, which does not share the same escaping rules.